### PR TITLE
♻️ Refactor express routing

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,0 +1,59 @@
+const express = require("express");
+const path = require("path");
+const {
+  insertShorty,
+  findShorty,
+  updateShorty,
+  findShorties,
+} = require("./shorties");
+
+const router = express.Router();
+
+router.get("/api/shorties", async (req, res) => {
+  try {
+    const shorties = await findShorties();
+    res.json(shorties);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json("Internal server error");
+  }
+});
+
+router.post("/api/shorties", async (req, res) => {
+  try {
+    const shorty = req.body;
+    await insertShorty(shorty);
+    res.status(201).json(`Shorty ${shorty.id} inserted`);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json("Internal server error");
+  }
+});
+
+// Serve any static files
+router.use(express.static(path.join(__dirname, "../client/build")));
+router.use(
+  "/storybook",
+  express.static(path.join(__dirname, "../client/storybook-static"))
+);
+
+router.get("/:id", async (req, res) => {
+  try {
+    const { id } = req.params;
+    const shorty = await findShorty({ id });
+    if (!shorty) {
+      return res.status(404).json(`Shorty ${id} not found`);
+    }
+    res.redirect(shorty.target);
+    updateShorty({ id }, { $inc: { views: 1 } });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json("Internal server error");
+  }
+});
+
+router.get("/", (req, res) => {
+  res.sendFile(path.join(__dirname, "../client/build/index.html"));
+});
+
+module.exports = router;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -9,24 +9,22 @@ const {
 
 const router = express.Router();
 
-router.get("/api/shorties", async (req, res) => {
+router.get("/api/shorties", async (req, res, next) => {
   try {
     const shorties = await findShorties();
     res.json(shorties);
   } catch (error) {
-    console.error(error);
-    res.status(500).json("Internal server error");
+    next(error);
   }
 });
 
-router.post("/api/shorties", async (req, res) => {
+router.post("/api/shorties", async (req, res, next) => {
   try {
     const shorty = req.body;
     await insertShorty(shorty);
     res.status(201).json(`Shorty ${shorty.id} inserted`);
   } catch (error) {
-    console.error(error);
-    res.status(500).json("Internal server error");
+    next(error);
   }
 });
 
@@ -37,7 +35,7 @@ router.use(
   express.static(path.join(__dirname, "../client/storybook-static"))
 );
 
-router.get("/:id", async (req, res) => {
+router.get("/:id", async (req, res, next) => {
   try {
     const { id } = req.params;
     const shorty = await findShorty({ id });
@@ -47,8 +45,7 @@ router.get("/:id", async (req, res) => {
     res.redirect(shorty.target);
     updateShorty({ id }, { $inc: { views: 1 } });
   } catch (error) {
-    console.error(error);
-    res.status(500).json("Internal server error");
+    next(error);
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -1,66 +1,13 @@
 require("dotenv").config();
 const express = require("express");
-const path = require("path");
 const { connect } = require("./lib/database");
-const {
-  findShorty,
-  insertShorty,
-  findShorties,
-  updateShorty,
-} = require("./lib/shorties");
+const routes = require("./lib/routes");
 
 const app = express();
 const port = process.env.PORT || 3001;
 
 app.use(express.json());
-
-// Serve any static files
-app.use(express.static(path.join(__dirname, "client/build")));
-app.use(
-  "/storybook",
-  express.static(path.join(__dirname, "client/storybook-static"))
-);
-
-app.get("/api/shorties", async (req, res) => {
-  try {
-    const shorties = await findShorties();
-    res.json(shorties);
-  } catch (error) {
-    console.error(error);
-    res.status(500).json("Internal server error");
-  }
-});
-
-app.post("/api/shorties", async (req, res) => {
-  try {
-    const shorty = req.body;
-    await insertShorty(shorty);
-    res.status(201).json(`Shorty ${shorty.id} inserted`);
-  } catch (error) {
-    console.error(error);
-    res.status(500).json("Internal server error");
-  }
-});
-
-app.get("/:id", async (req, res) => {
-  try {
-    const { id } = req.params;
-    const shorty = await findShorty({ id });
-    if (!shorty) {
-      return res.status(404).json(`Shorty ${id} not found`);
-    }
-    res.redirect(shorty.target);
-    console.log(`${id} requested`);
-    updateShorty({ id }, { $inc: { views: 1 } });
-  } catch (error) {
-    console.error(error);
-    res.status(500).json("Internal server error");
-  }
-});
-
-app.get("/", (req, res) => {
-  res.sendFile(path.join(__dirname, "client/build", "index.html"));
-});
+app.use(routes);
 
 async function run() {
   console.log("Connecting to database...");


### PR DESCRIPTION
Errors in async routes can be forwarded to the default error handler in Express with `next(error)`. See [error-handlin](https://expressjs.com/en/guide/error-handling.html).
In Express 5 it's not required to do that...but it's an alpha version. 

It makes sense to review the first two commits one-by-one.
Commits 3 and 4 are created due to a commit message change with `git commit --amend` (added wrong link to the commit body).